### PR TITLE
Minimum versions for Ignition dependencies

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -11,13 +11,13 @@ Build-Depends: cmake,
                libignition-common3-events-dev,
                libignition-common3-profiler-dev,
                libignition-math6-dev,
-               libignition-msgs4-dev,
+               libignition-msgs4-dev (>= 4.1.0),
                libignition-plugin-dev,
-               libignition-rendering2-ogre1-dev,
-               libignition-rendering2-ogre2-dev,
+               libignition-rendering2-ogre1-dev (>= 2.1.0),
+               libignition-rendering2-ogre2-dev (>= 2.1.0),
                libignition-transport7-core-dev,
                libignition-tools-dev,
-               libsdformat8-dev
+               libsdformat8-dev (>= 8.7.0)
 Vcs-Browser: https://bitbucket.org/ignitionrobotics/ign-sensors2-release
 Vcs-Hg: https://bitbucket.org/ignitionrobotics/ign-sensors2-release
 Homepage: http://ignitionrobotics.org/
@@ -28,13 +28,13 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
-         libignition-msgs4-dev,
+         libignition-msgs4-dev (>= 4.1.0),
          libignition-plugin-dev,
-         libignition-rendering2-ogre1-dev,
-         libignition-rendering2-ogre2-dev,
+         libignition-rendering2-ogre1-dev (>= 2.1.0),
+         libignition-rendering2-ogre2-dev (>= 2.1.0),
          libignition-transport7-core-dev,
          libignition-tools-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2 (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -58,7 +58,7 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-air-pressure (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -86,7 +86,7 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-altimeter (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -115,10 +115,10 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
-         libignition-msgs4-dev,
+         libignition-msgs4-dev (>= 4.1.0),
          libignition-transport7-core-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-camera (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -146,11 +146,11 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
-         libignition-msgs4-dev,
+         libignition-msgs4-dev (>= 4.1.0),
          libignition-transport7-core-dev,
          libignition-sensors2-core-dev,
          libignition-sensors2-camera-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-depth-camera (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -178,7 +178,7 @@ Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-imu (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -207,10 +207,10 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
-         libignition-msgs4-dev,
+         libignition-msgs4-dev (>= 4.1.0),
          libignition-transport7-core-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-lidar (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -238,11 +238,11 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
-         libignition-msgs4-dev,
+         libignition-msgs4-dev (>= 4.1.0),
          libignition-transport7-core-dev,
          libignition-sensors2-core-dev,
          libignition-sensors2-lidar-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-gpu-lidar (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -270,10 +270,10 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
-         libignition-msgs4-dev,
+         libignition-msgs4-dev (>= 4.1.0),
          libignition-transport7-core-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-logical-camera (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -302,7 +302,7 @@ Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-magnetometer (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -331,7 +331,7 @@ Depends: libignition-cmake2-dev,
          libignition-common3-events-dev,
          libignition-math6-dev,
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-rendering (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -357,9 +357,9 @@ Package: libignition-sensors2-rgbd-camera-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-msgs4-dev,
+         libignition-msgs4-dev (>= 4.1.0),
          libignition-sensors2-core-dev,
-         libsdformat8-dev,
+         libsdformat8-dev (>= 8.7.0),
          libignition-sensors2-rgbd-camera (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same


### PR DESCRIPTION
The main motivation is that right now, if a user only calls `sudo apt install libignition-sensors2` to upgrade only this package, they end up with a broken system because the dependencies are not up-to-date.

I based myself on the versions currently required on [ign-sensors's CMakeLists](https://github.com/ignitionrobotics/ign-sensors/blob/ign-sensors2/CMakeLists.txt), but we haven't been very good about updating these, so some could be out of date.